### PR TITLE
Use treesitter for folding

### DIFF
--- a/mackup/.config/nvim/lua/joshmedeski/autocmd.lua
+++ b/mackup/.config/nvim/lua/joshmedeski/autocmd.lua
@@ -21,3 +21,8 @@ vim.api.nvim_create_autocmd({ "BufNewFile", "BufFilePre", "BufRead" }, {
     vim.cmd([[set filetype=markdown wrap linebreak nolist]])
   end,
 })
+
+vim.api.nvim_create_autocmd({ "BufReadPost", "FileReadPost" }, {
+  pattern = {"*"},
+  command = "set foldlevel=99",
+})

--- a/mackup/.config/nvim/lua/joshmedeski/opt.lua
+++ b/mackup/.config/nvim/lua/joshmedeski/opt.lua
@@ -31,6 +31,10 @@ vim.opt.shiftwidth = 2
 vim.opt.expandtab = true
 vim.opt.smartindent = true
 
+-- folding
+vim.opt.foldmethod = "expr"
+vim.opt.foldexpr = "nvim_treesitter#foldexpr()"
+
 -- backup
 vim.opt.backup = false
 vim.opt.swapfile = false


### PR DESCRIPTION
This is a super small feature that:

Enables expr based folding in neovim based on treesitter parsers
Adds autocmd to ensure code is unfolded when new file or buffer is opened
Feel free to close the PR if you don't think you would use this, I'm just reviewing how my fork has diverged from your project, and trying to extract things you might find useful :-)